### PR TITLE
GithHub autentication, I have a problem on this test: 'Via OAuth2 Tok…

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -20,4 +20,6 @@ jobs:
     - run: npm ci
     - run: npm run build --if-present
     - name: Run tests
+      env:
+        ACCESS_TOKEN: ${{secrets.ACCESS_TOKEN}}
       run: npm test

--- a/test/GithubApi.Authentication.test.js
+++ b/test/GithubApi.Authentication.test.js
@@ -1,0 +1,32 @@
+const { StatusCodes } = require('http-status-codes');
+const { expect } = require('chai');
+const axios = require('axios');
+
+const urlBase = 'https://api.github.com';
+const githubUserName = 'Maosorio92';
+const repository = 'workshop-api-testing-js';
+
+describe('Github Api Test', () => {
+  describe('Authentication', () => {
+    it('Via OAuth2 Tokens by Header', async () => {
+      const response = await axios.get(`${urlBase}/repos/${githubUserName}/${repository}`, {
+        headers: {
+          Authorization: `token ${process.env.ACCESS_TOKEN}`
+        }
+      });
+
+      expect(response.status).to.equal(StatusCodes.OK);
+      expect(response.data.description).equal('This is a Workshop about Api Testing in JavaScript');
+    });
+
+    it('Via OAuth2 Tokens by parameter', async () => {
+      const response = await axios.get(
+        `${urlBase}/repos/${githubUserName}/${repository}`,
+        { access_token: process.env.ACCESS_TOKEN }
+      );
+
+      expect(response.status).to.equal(StatusCodes.OK);
+      expect(response.data.description).equal('This is a Workshop about Api Testing in JavaScript');
+    });
+  });
+});


### PR DESCRIPTION
…ens by Header', it is failing

Hello!
I found a problem on this test: 'Via OAuth2 Tokens by Header'

First, I set the Access Token, then, I run the tests, but I usually have to make "npm run lint -- --fix" first to fix problems, after that, I run the tests and this one is failing. So I continued with the next test:'Via OAuth2 Tokens by parameter', and that one is passing as I show on the following image. What should I do?

![image](https://user-images.githubusercontent.com/107366791/176506132-89bf1415-177b-47d1-ab86-23674bec3584.png)
